### PR TITLE
Use a non-native asset for XCM benchmarks on Asset Hubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update to SDK version `stable2503-5` ([polkadot-fellows/runtimes/pull/711](https://github.com/polkadot-fellows/runtimes/pull/711))
   - [[#711](https://github.com/polkadot-fellows/runtimes/pull/711)] Xcm: minor fix for compatibility with V4 ([SDK stable2503 #6503](https://github.com/paritytech/polkadot-sdk/pull/6503)).
+- Use `pallet-assets` instead of `pallet-balances` for XCM benchmarks on asset hubs ([polkadot-fellows/runtimes/pull/758](https://github.com/polkadot-fellows/runtimes/pull/758))
+  - This means XCM benchmarks will have a higher weight.
 
 ## [1.5.1] 22.05.2025
 

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1355,7 +1355,26 @@ mod benches {
 		}
 
 		fn get_asset() -> Asset {
-			Asset { id: AssetId(Location::parent()), fun: Fungible(ExistentialDeposit::get()) }
+			use frame_support::traits::tokens::fungible;
+			let account = frame_benchmarking::whitelisted_caller();
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				<Balances as fungible::Inspect<_>>::minimum_balance(),
+			));
+			let asset_id = 1984;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				account.into(),
+				true,
+				1u128,
+			));
+			let amount = 1_000_000u128;
+			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset {
+				id: AssetId(asset_location),
+				fun: Fungible(amount),
+			}
 		}
 	}
 
@@ -1425,7 +1444,26 @@ mod benches {
 		type TrustedReserve = TrustedReserve;
 
 		fn get_asset() -> Asset {
-			Asset { id: AssetId(KsmLocation::get()), fun: Fungible(UNITS) }
+			use frame_support::traits::tokens::fungible;
+			let (account, _) = pallet_xcm_benchmarks::account_and_location::<Runtime>(1);
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				ExistentialDeposit::get(),
+			));
+			let asset_id = 1984;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				account.into(),
+				true,
+				1u128,
+			));
+			let amount = 1_000_000u128;
+			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset {
+				id: AssetId(asset_location),
+				fun: Fungible(amount),
+			}
 		}
 	}
 

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1370,11 +1370,9 @@ mod benches {
 				1u128,
 			));
 			let amount = 1_000_000u128;
-			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
-			Asset {
-				id: AssetId(asset_location),
-				fun: Fungible(amount),
-			}
+			let asset_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset { id: AssetId(asset_location), fun: Fungible(amount) }
 		}
 	}
 
@@ -1459,11 +1457,9 @@ mod benches {
 				1u128,
 			));
 			let amount = 1_000_000u128;
-			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
-			Asset {
-				id: AssetId(asset_location),
-				fun: Fungible(amount),
-			}
+			let asset_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset { id: AssetId(asset_location), fun: Fungible(amount) }
 		}
 	}
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1301,7 +1301,26 @@ mod benches {
 		}
 
 		fn get_asset() -> Asset {
-			Asset { id: AssetId(Location::parent()), fun: Fungible(ExistentialDeposit::get()) }
+			use frame_support::traits::tokens::fungible;
+			let account = frame_benchmarking::whitelisted_caller();
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				<Balances as fungible::Inspect<_>>::minimum_balance(),
+			));
+			let asset_id = 1984;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				account.into(),
+				true,
+				1u128,
+			));
+			let amount = 1_000_000u128;
+			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset {
+				id: AssetId(asset_location),
+				fun: Fungible(amount),
+			}
 		}
 	}
 
@@ -1371,7 +1390,26 @@ mod benches {
 		type TrustedReserve = TrustedReserve;
 
 		fn get_asset() -> Asset {
-			Asset { id: AssetId(DotLocation::get()), fun: Fungible(UNITS) }
+			use frame_support::traits::tokens::fungible;
+			let (account, _) = pallet_xcm_benchmarks::account_and_location::<Runtime>(1);
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				ExistentialDeposit::get(),
+			));
+			let asset_id = 1984;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				account.into(),
+				true,
+				1u128,
+			));
+			let amount = 1_000_000u128;
+			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset {
+				id: AssetId(asset_location),
+				fun: Fungible(amount),
+			}
 		}
 	}
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1316,11 +1316,9 @@ mod benches {
 				1u128,
 			));
 			let amount = 1_000_000u128;
-			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
-			Asset {
-				id: AssetId(asset_location),
-				fun: Fungible(amount),
-			}
+			let asset_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset { id: AssetId(asset_location), fun: Fungible(amount) }
 		}
 	}
 
@@ -1405,11 +1403,9 @@ mod benches {
 				1u128,
 			));
 			let amount = 1_000_000u128;
-			let asset_location = Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
-			Asset {
-				id: AssetId(asset_location),
-				fun: Fungible(amount),
-			}
+			let asset_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(u32::from(asset_id).into())]);
+			Asset { id: AssetId(asset_location), fun: Fungible(amount) }
 		}
 	}
 


### PR DESCRIPTION
XCM benchmarks were always using the native asset which is not the worst case for various instructions and calls.
In this PR, I changed it to a custom asset in the assets pallet which is the worst case since it has to go through a double map instead of a single map to get the amount of an account.
